### PR TITLE
Add package: PaxD Publish v1.0.2

### DIFF
--- a/packages/com.mralfiem591.paxd-publish/package.yaml
+++ b/packages/com.mralfiem591.paxd-publish/package.yaml
@@ -2,7 +2,7 @@
 
 name: PaxD Publish
 author: mralfiem591
-version: 1.0.1
+version: 1.0.2
 description: A tool to validate and publish PaxD packages to the repository via GitHub PR.
 license: MIT
 tags:

--- a/packages/com.mralfiem591.paxd-publish/src/main.py
+++ b/packages/com.mralfiem591.paxd-publish/src/main.py
@@ -19,8 +19,8 @@ from datetime import datetime
 
 try:
     import requests
-    from github import Github, Auth
-    import git
+    from github import Github, Auth # type: ignore # In yaml dependencies - will be auto installed
+    import git # type: ignore # In yaml dependencies - will be auto installed
 except ImportError as e:
     print(f"Error: Missing required dependency: {e}")
     print("Please install required packages:")


### PR DESCRIPTION
## Changes & Updates

Fixed an error causing linters on remote connections to throw warnings; bump version to 1.0.2

## Package Submission

**Package ID:** `com.mralfiem591.paxd-publish`
**Name:** PaxD Publish
**Version:** 1.0.2
**Author:** mralfiem591
**Description:** A tool to validate and publish PaxD packages to the repository via GitHub PR.

### Package Details
- **License:** MIT
- **Tags:** cli, publishing, validation, github, tool, automation, package manager

### Files Included
- Package manifest (`package.yaml` or `paxd.yaml`)
- Source files in `src/` directory


---
*This PR was created automatically by paxd-publish*