### PR TITLE
Add package: PaxD Publish v1.0.3

### DIFF
--- a/packages/com.mralfiem591.paxd-publish/package.yaml
+++ b/packages/com.mralfiem591.paxd-publish/package.yaml
@@ -2,7 +2,7 @@
 
 name: PaxD Publish
 author: mralfiem591
-version: 1.0.2
+version: 1.0.3
 description: A tool to validate and publish PaxD packages to the repository via GitHub PR.
 license: MIT
 tags:

--- a/packages/com.mralfiem591.paxd-publish/src/main.py
+++ b/packages/com.mralfiem591.paxd-publish/src/main.py
@@ -408,16 +408,16 @@ def main():
         epilog="""
 Examples:
   # Publish package from current directory
-  paxd-publish
+  paxdp
   
   # Publish package from specific directory
-  paxd-publish --dir ./my-package
-  
+  paxdp --dir ./my-package
+
   # Include a custom message about changes
-  paxd-publish --message "Fixed critical bug in authentication module"
-  
+  paxdp --message "Fixed critical bug in authentication module"
+
   # Use custom repository
-  paxd-publish --owner myuser --repo myrepo
+  paxdp --owner myuser --repo myrepo
 
 Environment Variables:
   PAXD_GH_TOKEN: GitHub personal access token (required)


### PR DESCRIPTION
## Changes & Updates

Fix help message to use proper command (paxd-publish > paxdp); bumped to 1.0.3

## Package Submission

**Package ID:** `com.mralfiem591.paxd-publish`
**Name:** PaxD Publish
**Version:** 1.0.3
**Author:** mralfiem591
**Description:** A tool to validate and publish PaxD packages to the repository via GitHub PR.

### Package Details
- **License:** MIT
- **Tags:** cli, publishing, validation, github, tool, automation, package manager

### Files Included
- Package manifest (`package.yaml` or `paxd.yaml`)
- Source files in `src/` directory


---
*This PR was created automatically by paxd-publish*