### PR TITLE
Add package: PaxD v1.6.3

### DIFF
--- a/packages/com.mralfiem591.paxd/package.yaml
+++ b/packages/com.mralfiem591.paxd/package.yaml
@@ -2,7 +2,7 @@
 
 name: PaxD
 author: mralfiem591
-version: 1.6.2
+version: 1.6.3
 description: The main command line tool for using PaxD.
 license: MIT
 tags:

--- a/packages/com.mralfiem591.paxd/paxd
+++ b/packages/com.mralfiem591.paxd/paxd
@@ -4,7 +4,7 @@
     "pkg_info": {
         "pkg_name": "PaxD",
         "pkg_author": "mralfiem591",
-        "pkg_version": "1.6.2",
+        "pkg_version": "1.6.3",
         "pkg_description": "The main command line tool for using PaxD.",
         "pkg_license": "MIT",
         "tags": ["cli", "package manager", "installer", "windows", "tool", "gateway", "http", "repository"]

--- a/packages/com.mralfiem591.paxd/paxd-example
+++ b/packages/com.mralfiem591.paxd/paxd-example
@@ -7,7 +7,7 @@
     "pkg_info": { // Basic information about the package, most the values are pretty self-explanatory.
         "pkg_name": "PaxD",
         "pkg_author": "mralfiem591",
-        "pkg_version": "1.6.2",
+        "pkg_version": "1.6.3",
         "pkg_description": "The main command line tool for using PaxD.",
         "pkg_license": "MIT",
         "tags": ["cli", "package manager", "installer", "windows", "tool", "gateway", "http", "repository"] // Tags to show in this packages auto-generated README.html


### PR DESCRIPTION
## Changes & Updates

Update run_pkg.py to allow for running a package without SDK installed, if it isnt used; raise SDKException if it is used but not found; bump to 1.6.3

## Package Submission

**Package ID:** `com.mralfiem591.paxd`
**Name:** PaxD
**Version:** 1.6.3
**Author:** mralfiem591
**Description:** The main command line tool for using PaxD.

### Package Details
- **License:** MIT
- **Tags:** cli, package manager, installer, windows, tool, gateway, http, repository

### Files Included
- Package manifest (`package.yaml` or `paxd.yaml`)
- Source files in `src/` directory
- PaxD executable (`paxd`)

---
*This PR was created automatically by paxd-publish*