### PR TITLE
Add package: PaxD Publish v1.0.4

### DIFF
--- a/packages/com.mralfiem591.paxd-publish/package.yaml
+++ b/packages/com.mralfiem591.paxd-publish/package.yaml
@@ -2,7 +2,7 @@
 
 name: PaxD Publish
 author: mralfiem591
-version: 1.0.3
+version: 1.0.4
 description: A tool to validate and publish PaxD packages to the repository via GitHub PR.
 license: MIT
 tags:

--- a/packages/com.mralfiem591.paxd-publish/src/main.py
+++ b/packages/com.mralfiem591.paxd-publish/src/main.py
@@ -274,7 +274,7 @@ class PaxDPackagePublisher:
                 return None
             
             # Commit changes
-            commit_message = f"Add package {package_id} v{package_info.get('version', 'unknown')}\n\nAutomatically published via paxd-publish"
+            commit_message = f"Add/update/change package {package_id} v{package_info.get('version', 'unknown')}\n\nAutomatically published via paxd-publish"
             repo.git.commit('-m', commit_message)
             
             # Push branch
@@ -282,7 +282,7 @@ class PaxDPackagePublisher:
             origin.push(branch_name)
             
             # Create PR
-            pr_title = f"Add package: {package_info.get('name', package_id)} v{package_info.get('version', 'unknown')}"
+            pr_title = f"Add/update/change package: {package_info.get('name', package_id)} v{package_info.get('version', 'unknown')}"
             
             # Build PR body with optional custom message
             pr_body_parts = []


### PR DESCRIPTION
## Package Submission

**Package ID:** `com.mralfiem591.paxd-publish`
**Name:** PaxD Publish
**Version:** 1.0.4
**Author:** mralfiem591
**Description:** A tool to validate and publish PaxD packages to the repository via GitHub PR.

### Package Details
- **License:** MIT
- **Tags:** cli, publishing, validation, github, tool, automation, package manager

### Files Included
- Package manifest (`package.yaml` or `paxd.yaml`)
- Source files in `src/` directory


---
*This PR was created automatically by paxd-publish*