### PR TITLE
Add/update/change package: PaxD SDK v1.2.2

### DIFF
--- a/packages/com.mralfiem591.paxd-sdk/IMPORTANT
+++ b/packages/com.mralfiem591.paxd-sdk/IMPORTANT
@@ -1,14 +1,37 @@
-Our switch to YAML-first
+Major vulnerability fix
 
-paxd-sdk will be switching to a YAML-first install method. This means that your base "paxd" file will no longer be available. We will be serving a "package.yaml" instead.
+A major vulnerability was fixed in the PaxD SDK. This could allow for ACE (Arbitrary Code Execution) via package names with malicious characters. All package management functions now sanitize package names to prevent this issue.
 
-Why?
-It makes it easier for us to maintain, as we can read a YAML file easier than a JSONC file.
+This vulnerability is rated as EXTREME (8.1/10) due to the potential for severe damage if exploited.
 
-Will this change anything for me?
-As long as you are on a newer version of PaxD, no. PaxD has been transitioning to YAML-first already, and already contains code ported over from paxd-compiler (com.mralfiem591.paxd).
-If you are on a version new enough to display this message during installation, you are on a version new enough to support YAML.
-If you are on an older version, paxd-imageview will now become unavailable for you to use. Please update to a later version to keep using PaxD, via `paxd update -f paxd`.
+Please update to the latest version of the PaxD SDK to ensure your system's security.
 
-Thanks for taking the time to read this.
-    - mralfiem591 :)
+For example, an attacker could have a script with the following in it:
+
+```python
+SDK.Package.Install("com.mralfiem591.paxd-sdk && rm -rf /important/data")
+```
+This would execute the `rm -rf /important/data` command after installing the package, potentially deleting important data.
+
+This would execute the following exact command:
+
+```bash
+start cmd /c paxd install --skip-checksum com.mralfiem591.paxd-sdk && rm -rf /important/data
+```
+
+Please ensure you update to the latest version to mitigate this vulnerability.
+You can find more information on the GitHub issue being released soon for PAXD-2025-0003.
+
+All SDK endpoints for package management have been updated to sanitize package names by removing potentially dangerous characters such as `/`, `\`, `..`, `&`, `;`, and `|`, which should NEVER be in a package name.
+
+The following versions are affected:
+- PaxD SDK v1.0.0 to v1.0.4
+- PaxD SDK v1.1.0 to v1.1.4
+- PaxD SDK v1.2.0 to v1.2.1
+And any others below v1.2.1.
+
+Thank you for your attention to this important security update.
+
+NEVER download packages from unknown locations or sources outside of the official PaxD repository you do not trust.
+
+- mralfiem591, maintainer of PaxD and its SDK

--- a/packages/com.mralfiem591.paxd-sdk/package.yaml
+++ b/packages/com.mralfiem591.paxd-sdk/package.yaml
@@ -3,7 +3,7 @@
 
 name: PaxD SDK
 author: mralfiem591
-version: 1.2.0
+version: 1.2.2
 description: The main SDK (Software Development Kit) for PaxD.
 license: MIT
 tags:

--- a/packages/com.mralfiem591.paxd-sdk/src/main.py
+++ b/packages/com.mralfiem591.paxd-sdk/src/main.py
@@ -36,16 +36,27 @@ PackageDir = os.path.join(os.path.expandvars('%LOCALAPPDATA%'), 'PaxD')
 class Package:
     @staticmethod
     def Install(package_name: str):
+        # Remove dangerous characters from package name
+        package_name = package_name.replace('/', '').replace('\\', '').replace('..', '').replace('&', '').replace(';', '').replace('|', '')
+        
         # Install a package by calling PaxD
         os.system(f"start cmd /c paxd install --skip-checksum {package_name}")
 
     @staticmethod
     def Uninstall(package_name: str):
+        # Remove dangerous characters from package name
+        package_name = package_name.replace('/', '').replace('\\', '').replace('..', '').replace('&', '').replace(';', '').replace('|', '')
+        
+        
         # Uninstall a package by calling PaxD
         os.system(f"start cmd /c paxd uninstall {package_name}")
         
     @staticmethod
     def Update(package_name: str):
+        # Remove dangerous characters from package name
+        package_name = package_name.replace('/', '').replace('\\', '').replace('..', '').replace('&', '').replace(';', '').replace('|', '')
+        
+        
         # Update a package by calling PaxD
         os.system(f"start cmd /c paxd update -f --skip-checksum {package_name}")
 
@@ -267,33 +278,7 @@ class Repository:
         return ""
 
 # Part 8: System integration
-class System:
-    @staticmethod
-    def RunCommand(command: str, capture_output: bool = False, external: bool = False):
-        """Run a system command with optional output capture."""
-        if external:
-            command = f'start cmd /c {command}'
-        
-        if capture_output:
-            import subprocess
-            try:
-                result = subprocess.run(command, shell=True, capture_output=True, universal_newlines=True)
-                return {
-                    'success': result.returncode == 0,
-                    'stdout': result.stdout,
-                    'stderr': result.stderr,
-                    'returncode': result.returncode
-                }
-            except Exception as e:
-                return {
-                    'success': False,
-                    'stdout': '',
-                    'stderr': str(e),
-                    'returncode': -1
-                }
-        else:
-            return os.system(command) == 0
-    
+class System:    
     @staticmethod
     def GetEnvironmentVar(var_name: str, default: str = "") -> str:
         """Get an environment variable."""


### PR DESCRIPTION
## Changes & Updates

Fixed major security vulnerability rated EXTREME/8.1; bump to 1.2.2      A MAJOR vulnerability was found in PaxD SDK. Please update your SDK immediately to v1.2.2 or above.

## Package Submission

**Package ID:** `com.mralfiem591.paxd-sdk`
**Name:** PaxD SDK
**Version:** 1.2.2
**Author:** mralfiem591
**Description:** The main SDK (Software Development Kit) for PaxD.

### Package Details
- **License:** MIT
- **Tags:** sdk, development, devkit

### Files Included
- Package manifest (`package.yaml` or `paxd.yaml`)
- Source files in `src/` directory


---
*This PR was created automatically by paxd-publish*